### PR TITLE
Add support for "post-checkout" hook

### DIFF
--- a/internal/lib/add.go
+++ b/internal/lib/add.go
@@ -22,6 +22,7 @@ func Add(hook string, cmd string) {
 		"applypatch-msg",
 		"commit-msg",
 		"fsmonitor-watchman",
+		"post-checkout",
 		"post-update",
 		"pre-applypatch",
 		"pre-commit",


### PR DESCRIPTION
This is particularly useful to have a `husky install` hook that runs after checking out a new branch (that might have changes to the hooks). As this hook is supported by git and IIUC husky does little else than copying the contents from `.husky/hooks` to `.git/hooks` I expect this to work without issues